### PR TITLE
Fix accountx rule bug

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
@@ -1123,7 +1123,7 @@ public class AccountingProcessorHelper {
              ***/
             if (accountMappingTypeId == CashAccountsForLoan.FUND_SOURCE.getValue()) {
                 final ProductToGLAccountMapping paymentChannelSpecificAccountMapping = this.accountMappingRepository
-                        .findByProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(loanProductId,
+                        .findProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(loanProductId,
                                 PortfolioProductType.LOAN.getValue(), accountMappingTypeId, paymentTypeId);
                 if (paymentChannelSpecificAccountMapping != null) {
                     accountMapping = paymentChannelSpecificAccountMapping;
@@ -1200,7 +1200,7 @@ public class AccountingProcessorHelper {
              ***/
             if (accountMappingTypeId == CashAccountsForSavings.SAVINGS_REFERENCE.getValue()) {
                 final ProductToGLAccountMapping paymentChannelSpecificAccountMapping = this.accountMappingRepository
-                        .findByProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(savingsProductId,
+                        .findProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(savingsProductId,
                                 PortfolioProductType.SAVING.getValue(), accountMappingTypeId, paymentTypeId);
                 if (paymentChannelSpecificAccountMapping != null) {
                     accountMapping = paymentChannelSpecificAccountMapping;
@@ -1224,7 +1224,7 @@ public class AccountingProcessorHelper {
 
             if (accountMappingTypeId == CashAccountsForShares.SHARES_REFERENCE.getValue()) {
                 final ProductToGLAccountMapping paymentChannelSpecificAccountMapping = this.accountMappingRepository
-                        .findByProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(shareProductId,
+                        .findProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(shareProductId,
                                 PortfolioProductType.SHARES.getValue(), accountMappingTypeId, paymentTypeId);
                 if (paymentChannelSpecificAccountMapping != null) {
                     accountMapping = paymentChannelSpecificAccountMapping;

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/journalentry/service/AccountingProcessorHelper.java
@@ -252,6 +252,8 @@ public class AccountingProcessorHelper {
 
         }
 
+        // some comment
+
         return new SavingsDTO(loanId, loanProductId, officeId, currencyData.code(), cashBasedAccountingEnabled,
                 accrualBasedAccountingEnabled, newSavingsTransactions);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/domain/ProductToGLAccountMappingRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/accounting/producttoaccountmapping/domain/ProductToGLAccountMappingRepository.java
@@ -27,8 +27,10 @@ import org.springframework.data.repository.query.Param;
 public interface ProductToGLAccountMappingRepository
         extends JpaRepository<ProductToGLAccountMapping, Long>, JpaSpecificationExecutor<ProductToGLAccountMapping> {
 
-    ProductToGLAccountMapping findByProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(Long productId, int productType,
-            int financialAccountType, Long paymentType);
+    @Query("select mapping from ProductToGLAccountMapping mapping where mapping.productId= :productId and mapping.productType= :productType and mapping.financialAccountType= :financialAccountType and mapping.paymentType.id= :paymentType")
+    ProductToGLAccountMapping findProductIdAndProductTypeAndFinancialAccountTypeAndPaymentTypeId(@Param("productId") Long productId,
+            @Param("productType") int productType, @Param("financialAccountType") int financialAccountType,
+            @Param("paymentType") Long paymentType);
 
     @Query("select mapping from ProductToGLAccountMapping mapping where mapping.productId= :productId and mapping.productType= :productType and mapping.financialAccountType= :financialAccountType and mapping.charge.id= :chargeId")
     ProductToGLAccountMapping findProductIdAndProductTypeAndFinancialAccountTypeAndChargeId(@Param("productId") Long productId,


### PR DESCRIPTION
## Description

This fixes the bug on the CoA mapping to payment types involving loan products wrt advanced accounting rule.
In the advanced accounting rule for a loan product’s mapping with accounting, for a payment type to be associated with a specific CoA, we set a specific CoA in each loan product.
Usually, setting up such advanced accounting rule configuration should create appropriate accounting JL entries, but it didn't before - hence, the bug.

### Improvement

When getting the loan product mapped to a specific gl account, the gl account id returned is always that of cash clearing rather than that of the account associated with the mapping. As a result, the subsequent JL entry is inaccurate. This was fixed by modifying the query to get the appropriate loan product to account mapping.

