### PR TITLE
Modify loan application bug fix

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/CalculateLoanScheduleQueryFromApiJsonHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/CalculateLoanScheduleQueryFromApiJsonHelper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/CalculateLoanScheduleQueryFromApiJsonHelper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/CalculateLoanScheduleQueryFromApiJsonHelper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -136,31 +136,23 @@ public final class CalculateLoanScheduleQueryFromApiJsonHelper {
     public void validateSelectedPeriodFrequencyTypeIsTheSame(final List<ApiParameterError> dataValidationErrors,
             final Integer loanTermFrequency, final Integer loanTermFrequencyType, final Integer numberOfRepayments,
             final Integer repaymentEvery, final Integer repaymentEveryType) {
-        if (loanTermFrequencyType != null && !loanTermFrequencyType.equals(repaymentEveryType)) {
-            final ApiParameterError error = ApiParameterError.parameterError(
-                    "validation.msg.loan.loanTermFrequencyType.not.the.same.as.repaymentFrequencyType",
-                    "The parameters loanTermFrequencyType and repaymentFrequencyType must be the same.", "loanTermFrequencyType",
-                    loanTermFrequencyType, repaymentEveryType);
-            dataValidationErrors.add(error);
-        } else {
-            if (loanTermFrequency != null && repaymentEvery != null && numberOfRepayments != null) {
-                final int suggestsedLoanTerm = repaymentEvery * numberOfRepayments;
-                if (loanTermFrequency.intValue() < suggestsedLoanTerm) {
+        if (loanTermFrequency != null && repaymentEvery != null && numberOfRepayments != null) {
+            final int suggestedLoanTerm = repaymentEvery * loanTermFrequency.intValue();
+            if (numberOfRepayments < suggestedLoanTerm) {
+                final ApiParameterError error = ApiParameterError.parameterError(
+                        "validation.msg.loan.numberOfRepayments.less.than.repayment.structure.suggests",
+                        "The parameter numberOfRepayments is less than the suggested loan term as indicated by loanTermFrequency and repaymentEvery.",
+                        "loanTermFrequency", loanTermFrequency, numberOfRepayments, repaymentEvery);
+                dataValidationErrors.add(error);
+            } else {
+                if (numberOfRepayments > suggestedLoanTerm) {
                     final ApiParameterError error = ApiParameterError.parameterError(
-                            "validation.msg.loan.loanTermFrequency.less.than.repayment.structure.suggests",
-                            "The parameter loanTermFrequency is less than the suggest loan term as indicated by numberOfRepayments and repaymentEvery.",
+                            "validation.msg.loan.numberOfRepayments.greater.than.repayment.structure.suggests",
+                            "The parameter numberOfRepayments is greater than the suggested loan term as indicated by loanTermFrequency and repaymentEvery.",
                             "loanTermFrequency", loanTermFrequency, numberOfRepayments, repaymentEvery);
                     dataValidationErrors.add(error);
-                } else {
-                    if (loanTermFrequency.intValue() > suggestsedLoanTerm) {
-                        final ApiParameterError error = ApiParameterError.parameterError(
-                                "validation.msg.loan.loanTermFrequency.greater.than.repayment.structure.suggests",
-                                "The parameter loanTermFrequency is greater than the suggested loan term as indicated by numberOfRepayments and repaymentEvery.",
-                                "loanTermFrequency", loanTermFrequency, numberOfRepayments, repaymentEvery);
-                        dataValidationErrors.add(error);
-                    }
-
                 }
+
             }
         }
     }


### PR DESCRIPTION
When trying to modify a loan application even without any changes made, the application throws an error:

Loan term frequency period type must match that of repayment frequency period type.

This comes as a result of the validation mechanism not taking into account the semi-monthly improvement implemented.